### PR TITLE
Add parameter for using adata.raw.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Nucleic Acids Research, gkaa1014, https://doi.org/10.1093/nar/gkaa1014
 
 ###### (5) history_length - the length of history. In the benchmark data TENET provides best result when the length of history set to 1.
 
+###### (6) use_raw_data - whether to use raw data stored in adata.raw.X (True) or data from adata.X Note that data stored in adata.X may be inappropriate for TENET if you have run batch correction methods on your data. 
+
 #### Output
 
 	TE_result_matrix.txt - TEij, M genes x M genes matrix representing the causal relationship from GENEi to GENEj.
@@ -83,11 +85,11 @@ Nucleic Acids Research, gkaa1014, https://doi.org/10.1093/nar/gkaa1014
 ## 2. Run TENET with hdf5 file including PAGA pseudotime result
 #### Usage
 
-	./TENET4PAGAhdf5 [hdf5_file_name] [number_of_threads] [history_length]
+	./TENET4PAGAhdf5 [hdf5_file_name] [number_of_threads] [history_length] [use_raw_data]
 
 #### example
 
-	./TENET4PAGAhdf5 Data.Tuck/Tuck_PAGA510genes.h5ad 10 1
+	./TENET4PAGAhdf5 Data.Tuck/Tuck_PAGA510genes.h5ad 10 1 False
 
 ## 3. Run TENET from TF to target using expression data in a csv file and pseudotime result in a text file
 #### Usage

--- a/TENET4PAGAhdf5
+++ b/TENET4PAGAhdf5
@@ -1,7 +1,7 @@
 #!/bin/bash
-## specify $1 for input *.h5 file, $2 for number of parallel jobs, $3 for historyLength.
+## specify $1 for input *.h5 file, $2 for number of parallel jobs, $3 for historyLength, $4 for whether to use raw data.
 
-python hdf5_to_csv.py $1
+python hdf5_to_csv.py $1 $4
 # transpose input matrix from cell*gene to gene*cell, and generate list of all pairs of genes
 cat temp.csv | cut -d ',' -f 2- | tail -n +2 | sed 's/,/ /g' > cell_gene.tsv
 cat temp.csv | head -n 1 | cut -d ',' -f 2- | tr ',' '\n' > gene_names

--- a/hdf5_to_csv.py
+++ b/hdf5_to_csv.py
@@ -2,7 +2,11 @@ import scanpy
 import sys
 
 adata=scanpy.read_h5ad(sys.argv[1])
-data_matrix=adata.X
+raw=sys.argv[2]
+if raw:
+    data_matrix=adata.raw.X.toarray()
+else:
+    data=adata.X
 
 ofile = open("temp.csv","w")
 for gene_name in adata.var_names:


### PR DESCRIPTION
This PR is a response to the issue we have discussed by email. If someone has a hdf5 object that contains PAGA pseudotime results, they have most likely completed a full analysis pipeline, which includes batch correction. Batch corrected data cannot be used with TENET, as it contains negative values. Before, TENET would automatically use data stored in `adata.X`, which in the default (scanpy's) notation is the batch corrected data. This PR updates the code with a parameter to allow the user to choose to supply data stored in `adata.raw.X` instead. I have also updated the tutorial accordingly to the new changes, however, please modify it to fully fit with the style you are going for in your package. 